### PR TITLE
メッセージ投稿機能の実装

### DIFF
--- a/app/assets/stylesheets/room.css
+++ b/app/assets/stylesheets/room.css
@@ -89,3 +89,6 @@ select {
   height: 80px;
   width: 100%;
 }
+.field_with_errors {
+  display: contents;
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,21 @@
 class MessagesController < ApplicationController
   def index
+    @message = Message.new
+    @room = Room.find(params[:room_id])
+  end
+
+  def create
+    @room = Room.find(params[:room_id])
+    @message = @room.messages.new(message_params)
+    if @message.save
+      redirect_to room_messages_path(@room)
+    else
+      render :index
+    end
+  end
+  
+  private
+  def message_params
+    params.require(:message).permit(:content).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,6 +2,7 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @room = Room.find(params[:room_id])
+    @messages = Message.includes(:user)
   end
 
   def create
@@ -10,6 +11,7 @@ class MessagesController < ApplicationController
     if @message.save
       redirect_to room_messages_path(@room)
     else
+      @messages = Message.includes(:user)
       render :index
     end
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -16,6 +16,12 @@ class RoomsController < ApplicationController
     end
   end
 
+  def destroy
+    room = Room.find(params[:id])
+    room.destroy
+    redirect_to root_path
+  end
+
   def room_params
     params.require(:room).permit(:name, user_ids: [])
     

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -10,7 +10,7 @@ class RoomsController < ApplicationController
   def create
     @room = Room.new(room_params)
     if @room.save
-      redirect_to messages_index_path
+      redirect_to root_path
     else
       render :new
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
+
+  validates :content, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,6 +2,7 @@ class Room < ApplicationRecord
 
   has_many :room_users
   has_many :users, through: :room_users
+  has_many :messages
   
   validates :name, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,8 +1,8 @@
 class Room < ApplicationRecord
 
-  has_many :room_users
+  has_many :room_users, dependent: :destroy
   has_many :users, through: :room_users
-  has_many :messages
+  has_many :messages, dependent: :destroy
   
   validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
 
   has_many :room_users
   has_many :rooms, through: :room_users
+  has_many :messages
 end

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -1,7 +1,7 @@
 <div class="chat-header">
   <div class="left-header">
     <div class="header-title">
-      hogefuga
+      <%= @room.name %>
     </div>
   </div>
   <div class="right-header">

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -12,39 +12,7 @@
 </div>
 
 <div class="messages">
-  <div class="message">
-    <div class="upper-message">
-      <div class="message-user">
-        Tom
-      </div>
-      <div class="message-date">
-        2020/3/31(Wed) 12:43:30
-      </div>
-    </div>
-    <div class="lower-message">
-      <div class="message-content">
-        おはよう
-      </div>
-    </div>
-  </div>
-
-   <div class="message">
-    <div class="upper-message">
-      <div class="message-user">
-        Tom
-      </div>
-      <div class="message-date">
-        2020/3/31(Wed) 12:43:30
-      </div>
-    </div>
-    <div class="lower-message">
-      <div class="message-content">
-        おはよう
-      </div>
-    </div>
-  </div>
-
-
+  <%= render partial: "message", collection: @messages%>
 </div>
 
   <%= form_with model: [@room, @message], class: "form", local: true do |f| %>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -6,7 +6,8 @@
   </div>
   <div class="right-header">
     <div class="header-button">
-      <a href="#">チャットを終了する</a>
+      <%# <a href="#">チャットを終了する</a> %>
+      <%= link_to "チャットを終了する",room_path(@room), method: :delete %>
     </div>
   </div>
 </div>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -47,13 +47,17 @@
 
 </div>
 
-<div class="form">
-  <div class="form-input">
-    <input type="text" class="form-message" placeholder= "type a message">
+  <%= form_with model: [@room, @message], class: "form", local: true do |f| %>
+    <div class="form-input">
+      <%# <input type="text" class="form-message" placeholder= "type a message"> %>
+      <%= f.text_field :content, class: "form-message", placeholder: "type a message" %>
       <label class="form-image">
         <span class="image-file">画像</span>
-        <input type="file" class="hidden">
+        <%# <input type="file" class="hidden"> %>
+        <% f.file_field :image, class: "hidden"%>
       </label>
-  </div>
-  <input class="form-submit" type="submit" value="送信">
+    </div>
+    <%# <input class="form-submit" type="submit" value="送信"> %>
+    <%= f.submit "送信", class: "form-submit" %>
+  <% end %>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,0 +1,15 @@
+<div class="message">
+  <div class="upper-message">
+    <div class="message-user">
+      <%= message.user.name%>
+    </div>
+    <div class="message-date">
+      <%= message.created_at %>
+    </div>
+  </div>
+  <div class="lower-message">
+    <div class="message-content">
+      <%= message.content %>
+    </div>
+  </div>
+</div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -4,7 +4,7 @@
       <%= message.user.name%>
     </div>
     <div class="message-date">
-      <%= message.created_at %>
+      <%= l message.created_at %>
     </div>
   </div>
   <div class="lower-message">

--- a/app/views/messages/_side_bar.html.erb
+++ b/app/views/messages/_side_bar.html.erb
@@ -15,7 +15,7 @@
     <div class="room">
       <div class="room-name">
         <%# <a href="#">TECHROOM</a> %>
-        <%= link_to room.name, "#" %>
+        <%= link_to room.name, room_messages_path(room) %>
       </div>
     </div>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module ChatApp2
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get 'messages/index'
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create] do
+  resources :rooms, only: [:new, :create, :destroy] do
     resources :messages, only: [:index, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   get 'messages/index'
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create]
+  resources :rooms, only: [:new, :create] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20230131060509_create_messages.rb
+++ b/db/migrate/20230131060509_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_29_094109) do
+ActiveRecord::Schema.define(version: 2023_01_31_060509) do
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
 
   create_table "room_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "room_id", null: false
@@ -40,6 +50,8 @@ ActiveRecord::Schema.define(version: 2023_01_29_094109) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"
   add_foreign_key "room_users", "users"
 end


### PR DESCRIPTION
# What
テキストの投稿・ルームの削除を行う実装
# Why
テキストの投稿機能を実装すること
投稿したテキストをメッセージ一覧画面に表示させること
投稿時刻を日本時刻へ変更すること
テキストが空の状態ではテキストを送れないようにバリデーションを設定すること
現在のチャットルーム名をメッセージ一覧画面のヘッダーに表示すること
チャットルーム削除機能を実装すること

